### PR TITLE
compute inverse even if there is an omocodia + test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ node_modules
 # Optional npm cache directory
 .npm
 
+# intellij files
+.idea
+
 # Optional REPL history
 .node_repl_history
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codice-fiscale-js",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3718,7 +3718,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3739,12 +3740,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3759,17 +3762,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3886,7 +3892,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3898,6 +3905,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3912,6 +3920,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3919,12 +3928,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3943,6 +3954,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4023,7 +4035,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4035,6 +4048,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4120,7 +4134,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4156,6 +4171,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4175,6 +4191,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4218,12 +4235,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/constants.js
+++ b/src/constants.js
@@ -104,4 +104,17 @@ export const OMOCODIA_TABLE = {
   9: 'V'
 }
 
+export const OMOCODIA_TABLE_INVERSE = {
+  'L': '0',
+  'M': '1',
+  'N': '2',
+  'P': '3',
+  'Q': '4',
+  'R': '5',
+  'S': '6',
+  'T': '7',
+  'U': '8',
+  'V': '9'
+}
+
 export const CHECK_CODE_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -241,6 +241,21 @@ describe('Calcolo codice fiscale inverso -> metodo .computeInverse', () => {
   })
 
 
+  /*  Nome: GIUSEPPE
+   *  Cognome: ESPOSITO
+   *  Nato a : NAPOLI (NP)
+   *  Giorno : 18
+   *  Mese   : Febbraio (2)
+   *  Anno   : 1975
+   *  Sesso  : M
+   *  OMOCODIA: true
+   */
+  let giuseppe_esposito_cf =  "SPSGPP75B18F83VM";
+
+  test('restituisce la città natale corretta nonostante omocodia', () => {
+    expect(CodiceFiscale.computeInverse(giuseppe_esposito_cf).birthplace).toEqual('NAPOLI')
+  })
+
 })
 
 


### PR DESCRIPTION
Fix che permette di ricavare comune e data di nascita anche in caso di codici fiscali generati in seguito ad omocodia e quindi con alcune lettere dove dovrebbero esserci i numeri indicanti la data di nascita e il comune.
Aggiunto anche un test relativo a ciò.