### PR TITLE
Added types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.3.0",
   "description": "The Italian Tax Code Library for Javascript and Typescript",
   "main": "dist/codice.fiscale.commonjs2.js",
+  "types": "types/codice-fiscale.d.ts",
   "repository": {
     "type": "git",
     "url": "git://github.com/lucavandro/CodiceFiscaleJS.git"


### PR DESCRIPTION
Per fare in modo che `tsc` trovi i file di dicharazione pubblicati con una libreria js bisogna aggiungere il campo `types` al package.json indicando dove sta il file `.d.ts` principale, se no quando provi ad importare la libreria `tsc` dice che non trova le dichiarazioni associate.

https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package