### PR TITLE
Update utils.js fix-timezone-getvaliddate

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -27,15 +27,28 @@ export function isValidDate (d, m, y) {
   const month = m - 1
   return month >= 0 && month < 12 && d > 0 && d <= daysInMonth(month, y)
 }
-export function getValidDate (d, m, y) {
+export function getValidDate(d, m, y) {
   if (typeof d === 'string' && m === undefined && y === undefined) {
-    return new Date(d)
-  } else if (isValidDate(d, m, y)) {
-    return new Date(y, m - 1, d, 0, 0, 0, 0)
-  } else {
-    throw new Error(`The date ${y}/${m}/${d} is not a valid date`)
+    if (d.includes('-')) {
+      const [year, month, day] = d.split('-').map(Number);
+      const date = new Date();
+      date.setFullYear(year, month - 1, day);
+      date.setHours(12, 0, 0, 0); // mezzogiorno per evitare errori di fuso
+      return date;
+    }
+    return new Date(d);
   }
+
+  if (typeof d === 'number' && typeof m === 'number' && typeof y === 'number') {
+    const date = new Date();
+    date.setFullYear(y, m - 1, d);
+    date.setHours(12, 0, 0, 0);
+    return date;
+  }
+
+  throw new Error(`The date ${y}/${m}/${d} is not a valid date`);
 }
+
 export function extractVowels (str) {
   return str.replace(/[^AEIOU]/gi, '')
 }


### PR DESCRIPTION
Fix: gestione corretta timezone per date ISO in getValidDate

Questo fix risolve un bug che si verifica quando si utilizza una stringa in formato ISO (YYYY-MM-DD) per generare una data con new Date(...).

In ambienti con fuso orario negativo (es. California), la funzione new Date("1978-10-09") genera una data a mezzanotte UTC, che in quel fuso viene interpretata come il giorno precedente.

Esempio del problema:

Input: "1978-10-09"

Output effettivo in California: 1978-10-08T17:00:00.000Z

Codice Fiscale generato: errato

Il fix propone:

Parsing manuale della data (split di stringa YYYY-MM-DD)

Impostazione dell’orario a mezzogiorno locale (12:00:00) per evitare errori di fuso

Il risultato è una gestione coerente della data di nascita indipendentemente dal fuso orario del browser o del server.