### PR TITLE
feat: export COMUNI and PROVINCE data as public constants

### DIFF
--- a/src/codice-fiscale.js
+++ b/src/codice-fiscale.js
@@ -1,6 +1,8 @@
 import { Comune } from './comune'
 import { CHECK_CODE_CHARS, CHECK_CODE_EVEN, CHECK_CODE_ODD, MONTH_CODES, NUMERIC_POS, OMOCODIA_TABLE, OMOCODIA_TABLE_INVERSE } from './constants'
 import { extractConsonants, extractVowels, getValidDate, birthplaceFields, getAllSubsets } from './utils'
+import { COMUNI_LIST } from './lista-comuni'
+import { PROVINCE } from './lista-province'
 
 class CodiceFiscale {
   get day () {
@@ -250,4 +252,6 @@ class CodiceFiscale {
 CodiceFiscale.utils = {
   birthplaceFields: birthplaceFields
 }
+CodiceFiscale.COMUNI = COMUNI_LIST
+CodiceFiscale.PROVINCE = PROVINCE
 module.exports = CodiceFiscale;

--- a/src/lista-comuni.js
+++ b/src/lista-comuni.js
@@ -13655,3 +13655,11 @@ export const COMUNI = [ ["A001","PD","ABANO BAGNI",0],
 ["M205","MI","ZUNICO",0],
 ["M206","CA","ZURI",0],
 ]
+
+// Export a more user-friendly structure for external consumption
+export const COMUNI_LIST = COMUNI.map(([cc, prov, nome, active]) => ({
+  belfioreCode: cc,
+  province: prov,
+  name: nome,
+  active: active === 1
+}))

--- a/types/codice-fiscale.d.ts
+++ b/types/codice-fiscale.d.ts
@@ -3,6 +3,17 @@ import { birthplaceFields } from "./utils";
 
 export type Gender = "F" | "M";
 
+export interface IComuneData {
+    belfioreCode: string;
+    province: string;
+    name: string;
+    active: boolean;
+}
+
+export interface IProvinceData {
+    [key: string]: string;
+}
+
 export interface ICodiceFiscaleObject {
     name: string;
     surname: string;
@@ -26,6 +37,8 @@ declare class CodiceFiscale {
     static utils: {
         birthplaceFields: typeof birthplaceFields;
     };
+    static COMUNI: IComuneData[];
+    static PROVINCE: IProvinceData;
     birthday: Date;
     birthplace: Comune;
     name: string;
@@ -55,3 +68,6 @@ declare class CodiceFiscale {
 }
 
 export default CodiceFiscale;
+export { CodiceFiscale };
+export const COMUNI: IComuneData[];
+export const PROVINCE: IProvinceData;


### PR DESCRIPTION
Exposes the internal municipality (comuni) and province data as public exports to allow external usage for validation, mapping, and UI components.

Changes:
- Add COMUNI_LIST export with user-friendly structure (belfioreCode, province, name, active)
- Export PROVINCE mapping as static property on CodiceFiscale class
- Add TypeScript definitions for IComuneData and IProvinceData interfaces
- Support both CommonJS and ES6 module imports

This allows developers to:
- Import data directly: import { COMUNI, PROVINCE } from 'codice-fiscale-js'
- Access via class: CodiceFiscale.COMUNI and CodiceFiscale.PROVINCE
- Reuse official municipality data without duplication
- Build forms, selectors, and validation services with type safety

Fixes: Resolves feature request for exporting comuni and province data

🤖 Generated with [Claude Code](https://claude.ai/code)